### PR TITLE
Modify actions to only run on PRs

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 name: Continuous integration
 

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -18,7 +18,7 @@ jobs:
           command: check
 
   test:
-    name: Test Suite
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           command: test
 
   fmt:
-    name: Rustfmt
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on: [pull_request]
 
-name: Continuous integration
+name: CI
 
 jobs:
   check:


### PR DESCRIPTION
Avoid double-running by only running on PRs, not on pushes to arbitrary
branches.